### PR TITLE
Require minimist explicitly

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Returns configuration settings object.
 
   - `[options]` {Object}
     - `[dirname]`       Root directory of your app package.  Required to find `package.json` and package settings file.
-    - `[cli]`           {Object} Command line interface parsing options.  Refer to [minimist](https://github.com/substack/minimist) documentation.
+    - `[cli]`           {Object} Command line interface parsing options.  Refer to [minimist](https://github.com/substack/minimist) documentation. Define as empty object to use default values.
     - `[clone]`         {Boolean} If `true`, copies package settings file to users home directory. (default: `false`).
     - `[merge]`         {String} Merge attributes using `'shallow'` or `'deep'` recursive merging (default: `'shallow'`).
     - `[configFile]`    {String} Settings file name. (default: `.<appname>.json`).

--- a/lib/index.js
+++ b/lib/index.js
@@ -221,7 +221,10 @@ module.exports = {
         }
 
         // Parse and Merge command line options:
-        var cli_cfg = require('minimist')(process.argv.slice(2), options.cli || {});
+        if(options.cli) {
+            var cli_cfg = require('minimist')(process.argv.slice(2), options.cli);
+        }
+        
         if (cli_cfg) {
             validator2('command line args', cli_cfg, false);
             cfg = fnMerge(cfg, cli_cfg);


### PR DESCRIPTION
Require the [cli] option to be explicitly stated before requiring the minimist package.

This will allow cli-config to serve in larger projects as a user configuration management tool and work in conjunction with other tools for parsing command line arguments. 
